### PR TITLE
h2h param passing bugfix

### DIFF
--- a/state_machine/state_machine/state_machine_params.py
+++ b/state_machine/state_machine/state_machine_params.py
@@ -66,8 +66,13 @@ class StateMachineParams:
         node.set_descriptor("n_loc_wpnts", descriptor=descriptor)
         self.n_loc_wpnts: int = node.get_parameter("n_loc_wpnts").value
         
-        self.overtake_mode = "spliner"
-        """Overtake mode\nOnly spliner is supported at the moment"""
+        descriptor = ParameterDescriptor(
+            description="Overtake mode\nOnly spliner is supported at the moment\n",
+            type=ParameterType.PARAMETER_STRING,
+            read_only=False,
+        )
+        node.set_descriptor("overtake_mode", descriptor=descriptor)
+        self.overtake_mode: str = node.get_parameter("overtake_mode").value
         
         descriptor = ParameterDescriptor(
             description="Voltage threshold for the car, below which the car is considered to be low bat.\n",

--- a/state_machine/state_machine/state_machine_params.py
+++ b/state_machine/state_machine/state_machine_params.py
@@ -71,7 +71,7 @@ class StateMachineParams:
             type=ParameterType.PARAMETER_STRING,
             read_only=False,
         )
-        node.set_descriptor("overtake_mode", descriptor=descriptor)
+        node.declare_parameter("overtake_mode", "spliner", descriptor=descriptor)
         self.overtake_mode: str = node.get_parameter("overtake_mode").value
         
         descriptor = ParameterDescriptor(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overtake mode is now configurable at runtime via a parameter (defaults to "spliner"), allowing the system to use the configured value instead of a fixed setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->