### PR TITLE
solve the narrow track filtered mapping problem (hopefully)

### DIFF
--- a/stack_master/config/global_planner/global_planner_params.yaml
+++ b/stack_master/config/global_planner/global_planner_params.yaml
@@ -5,7 +5,7 @@ global_planner:
     safety_width: 0.7  # [m] including the width of the car
     safety_width_sp: 0.7  # [m] including the width of the car for shortest path optimization
     occupancy_grid_threshold: 10
-    filter_kernel_size: 9 # how much filtering to do to raw map images
+    filter_kernel_size: 5 # how much filtering to do to raw map images, droped down from 9 to solve the issue with too much filtering when the track is narrow 
     reverse_mapping: False  # By default, do not reverse the direction of the track
 
     show_plots: False


### PR DESCRIPTION
Decreased filter kernel size from 9 to 5 to reduce excessive filtering on narrow tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted global planner filtering configuration to optimize map processing performance during route planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->