### PR TITLE
Added new bashrc scripts to make our life easier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings (required for execution on Linux/Ubuntu)
+*.sh text eol=lf
+.install_utils/bashrc/* text eol=lf

--- a/.install_utils/bashrc/.bashrc_aliases
+++ b/.install_utils/bashrc/.bashrc_aliases
@@ -5,8 +5,7 @@
 map_with_drawing() {
     ros2 launch map_editor map_editor_launch.xml \
         map_name:="$1" \
-        map_editor_mapping:=True \
-        racecar_version:=NUCNUC
+        map_editor_mapping:=True
 }
 
 # Re-run global trajectory planning on an existing map (no remapping)
@@ -14,8 +13,23 @@ map_with_drawing() {
 plan_racing_line() {
     ros2 launch map_editor map_editor_launch.xml \
         map_name:="$1" \
+        map_editor_mapping:=False
+}
+
+# Used to run mapping from a rosbag
+# Usage: mapping_from_rosbag <MAP_NAME>
+mapping_from_rosbag() {
+    ros2 launch map_editor map_editor_launch.xml map_name:=<MAP_NAME> map_editor_mapping:=False 
+    ros2 launch map_editor map_editor_launch.xml \
+        map_name:="$1" \
         map_editor_mapping:=False \
-        racecar_version:=NUCNUC
+        use_sim_time:=True
+}
+
+# Used to play  rosbag that will be used for mapping (run on a separate terminal simultaneously with mapping_from_rosbag)
+# Usage: play_rosbag <BAG_NAME>
+play_rosbag() {
+    ros2 bag play "$1" --clock
 }
 
 # Wipe failed colcon build artifacts and rebuild (skipping simulation packages)

--- a/.install_utils/bashrc/.bashrc_aliases
+++ b/.install_utils/bashrc/.bashrc_aliases
@@ -1,0 +1,31 @@
+# Ingenuity Labs Racing custom aliases - edit this file on the host, sourced inside the container
+
+# Launch maapping so that we can draw on the PNG file (run "drawing" afterwards)
+# Usage: map_with_drawing <MAP_NAME>
+map_with_drawing() {
+    ros2 launch map_editor map_editor_launch.xml \
+        map_name:="$1" \
+        map_editor_mapping:=True \
+        racecar_version:=NUCNUC
+}
+
+# Re-run global trajectory planning on an existing map (no remapping)
+# Usage: plan_racing_line <MAP_NAME>
+plan_racing_line() {
+    ros2 launch map_editor map_editor_launch.xml \
+        map_name:="$1" \
+        map_editor_mapping:=False \
+        racecar_version:=NUCNUC
+}
+
+# Wipe failed colcon build artifacts and rebuild (skipping simulation packages)
+clear_failed_build() {
+    cd ~/ws && \
+    rm -rf build log install && \
+    colcon build --symlink-install --packages-ignore f110_gym f1tenth_gym_ros && \
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    source ~/ws/install/setup.bash
+}
+
+# Fix display forwarding if RViz or GUI tools fail to open
+alias export_display='export DISPLAY=localhost:10.0'

--- a/.install_utils/bashrc/.bashrc_aliases
+++ b/.install_utils/bashrc/.bashrc_aliases
@@ -19,7 +19,6 @@ plan_racing_line() {
 # Used to run mapping from a rosbag
 # Usage: mapping_from_rosbag <MAP_NAME>
 mapping_from_rosbag() {
-    ros2 launch map_editor map_editor_launch.xml map_name:=<MAP_NAME> map_editor_mapping:=False 
     ros2 launch map_editor map_editor_launch.xml \
         map_name:="$1" \
         map_editor_mapping:=False \
@@ -35,7 +34,7 @@ play_rosbag() {
 # Wipe failed colcon build artifacts and rebuild (skipping simulation packages)
 clear_failed_build() {
     cd ~/ws && \
-    rm -rf build log install && \
+    rm -rf build/* log/* install/* && \
     colcon build --symlink-install --packages-ignore f110_gym f1tenth_gym_ros && \
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
     source ~/ws/install/setup.bash

--- a/.install_utils/bashrc/.bashrc_forzaeth
+++ b/.install_utils/bashrc/.bashrc_forzaeth
@@ -4,3 +4,6 @@ source /home/$USERNAME/ws/install/setup.bash
 alias sauce='source /opt/ros/${ROS_DISTRO}/setup.bash && source /home/${USERNAME}/ws/install/setup.bash'
 alias scripz='cd /home/${USERNAME}/ws/src/race_stack/stack_master/scripts'
 export ROS_DOMAIN_ID=42
+
+# Source user aliases from the mounted race_stack volume
+[ -f ~/ws/src/race_stack/.install_utils/bashrc/.bashrc_aliases ] && source ~/ws/src/race_stack/.install_utils/bashrc/.bashrc_aliases


### PR DESCRIPTION
1. Created bashrc_aliases to set up our bashrc shortcuts.
2. Modified .bashrc_forzaeth so that our shortcuts persist in case of a container rebuild
3. Created .gitattributes file so that my Windows line endings don't ruin the bash scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shell commands and aliases to streamline map editing/mapping modes, play recorded bags with clock support, clear and rebuild a workspace after failed builds, and set/display GUI forwarding.

* **Chores**
  * Enforced LF line endings for shell scripts for Linux-compatible newlines.
  * Shell initialization now loads additional user-defined aliases/configuration automatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ingenuity-Labs-Racing/ForzaETH_Race_Stack/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->